### PR TITLE
Bump org.apache.commons:commons-compress in /packages

### DIFF
--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.15</version>
+			<version>1.26.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Bumps org.apache.commons:commons-compress from 1.15 to 1.26.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-compress dependency-type: direct:production ...